### PR TITLE
Fix iPad toolbar scrolling issue

### DIFF
--- a/apps/teskooano/src/core/controllers/toolbar/ToolbarController.template.ts
+++ b/apps/teskooano/src/core/controllers/toolbar/ToolbarController.template.ts
@@ -38,6 +38,8 @@ template.innerHTML = `
       gap: var(--space-sm); /* Smaller gap for widgets */
       display: flex; /* Explicitly ensure it's a flex container, though inherited via .toolbar-section */
       align-items: center; /* Align items vertically in the center */
+      touch-action: pan-x; /* Allow horizontal scrolling on touch devices */
+      -webkit-overflow-scrolling: touch; /* Enable momentum scrolling on iOS */
     }
 
     .widget-area::-webkit-scrollbar, .widget-area::-webkit-scrollbar-button { display: none; }

--- a/apps/teskooano/src/core/controllers/toolbar/ToolbarController.ts
+++ b/apps/teskooano/src/core/controllers/toolbar/ToolbarController.ts
@@ -86,11 +86,24 @@ export class ToolbarController {
   }
 
   /**
-   * Detects if the current device is a mobile device based on window width.
-   * @returns `true` if the window width is less than 768px, otherwise `false`.
+   * Detects if the current device is a mobile device based on window width and device characteristics.
+   * @returns `true` if the device is mobile or tablet (including iPad), otherwise `false`.
    */
   public detectMobileDevice(): boolean {
-    return window.innerWidth < 768;
+    // Check for touch capability and screen size
+    const hasTouchScreen = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+    const isSmallScreen = window.innerWidth < 768;
+    const isMediumScreen = window.innerWidth < 1024;
+    
+    // Detect iPad specifically (including iPad Pro)
+    const userAgent = navigator.userAgent.toLowerCase();
+    const isIpad = userAgent.includes('ipad') || 
+                   (userAgent.includes('macintosh') && hasTouchScreen);
+    
+    // Detect other tablets based on screen size and touch capability
+    const isTablet = hasTouchScreen && window.innerWidth >= 768 && window.innerWidth <= 1024;
+    
+    return isSmallScreen || isIpad || isTablet;
   }
 
   /**

--- a/packages/app/design-system/src/layout/app.css
+++ b/packages/app/design-system/src/layout/app.css
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 #app {
-  touch-action: none;
+  touch-action: pan-y; /* Allow vertical scrolling but prevent horizontal */
   width: 100%;
   flex: 1;
   margin: 0 auto;
@@ -26,8 +26,22 @@
   flex-wrap: nowrap;
   gap: var(--spacing-md); /* Use new spacing */
   flex-shrink: 0;
-  overflow: hidden;
+  overflow-x: auto; /* Allow horizontal scrolling */
+  overflow-y: hidden; /* Hide vertical overflow */
   position: relative;
+  touch-action: pan-x; /* Allow horizontal scrolling on touch devices */
+  -webkit-overflow-scrolling: touch; /* Enable momentum scrolling on iOS */
+}
+
+/* Hide toolbar scrollbar */
+#toolbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* Ensure toolbar items don't shrink and maintain proper scrolling behavior */
+#toolbar > * {
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 /* Style the basic button within the toolbar using the new base style */

--- a/packages/app/design-system/src/layout/responsive.css
+++ b/packages/app/design-system/src/layout/responsive.css
@@ -12,14 +12,16 @@
 @media only screen and (max-width: 1024px) {
   #toolbar {
     gap: var(--spacing-sm); /* Less gap */
-    flex-wrap: wrap;
-    height: auto; /* Allow wrapping */
+    flex-wrap: nowrap; /* Prevent wrapping on tablets - use horizontal scroll instead */
+    height: var(--toolbar-height); /* Fixed height for tablets */
     min-height: var(--toolbar-height); /* Ensure min height */
     padding: var(--spacing-sm) var(--spacing-md); /* Adjust padding */
+    overflow-x: auto; /* Enable horizontal scrolling */
+    -webkit-overflow-scrolling: touch; /* Enable momentum scrolling on iOS */
   }
 
   #toolbar > * {
-    flex-shrink: 1;
+    flex-shrink: 0; /* Prevent shrinking to allow horizontal scroll */
     flex-basis: auto;
     min-width: 0;
   }
@@ -28,6 +30,11 @@
   #toolbar button {
     padding: var(--space-1) var(--space-2);
     font-size: var(--font-size-small);
+  }
+
+  /* Hide toolbar scrollbar on tablets */
+  #toolbar::-webkit-scrollbar {
+    display: none;
   }
 
   /* Example: Hide text on specific buttons */


### PR DESCRIPTION
Fix iPad toolbar horizontal scrolling to make all buttons accessible.

The toolbar on iPad was not horizontally scrollable, preventing users from accessing buttons like "Sol". This was caused by a combination of `touch-action: none` on the main app container, inadequate iPad detection logic, and missing `touch-action: pan-x` properties on scrollable elements, compounded by iOS/WebKit scrolling quirks. This PR updates CSS properties and enhances mobile detection to ensure smooth horizontal scrolling on touch devices, especially iPads.